### PR TITLE
compare local and upstream

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -24,6 +24,7 @@ sphinx-rtd-theme = "*"
 typed-ast = "*"
 typing-extensions = "*"
 types-colorama = "*"
+importlib-metadata = "*"
 
 [requires]
 python_version = "3.7"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "1ae094b73e715c086d736858694493d675579a04e54d0dca2495e2f1931ac1a2"
+            "sha256": "81e6d294c9ccc392955cce9523e83305a3c24cd7734895a2d465b683f83fa689"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -48,6 +48,14 @@
             "index": "pypi",
             "version": "==3.1.17"
         },
+        "importlib-metadata": {
+            "hashes": [
+                "sha256:833b26fb89d5de469b24a390e9df088d4e52e4ba33b01dc5e0e4f41b81a16c00",
+                "sha256:b142cc1dd1342f31ff04bb7d022492b09920cb64fed867cd3ea6f80fe3ebd139"
+            ],
+            "markers": "python_version < '3.8'",
+            "version": "==4.5.0"
+        },
         "smmap": {
             "hashes": [
                 "sha256:7e65386bd122d45405ddf795637b7f7d2b532e7e401d46bbe3fb49b9986d5182",
@@ -63,6 +71,15 @@
             "index": "pypi",
             "version": "==1.1.0"
         },
+        "typing-extensions": {
+            "hashes": [
+                "sha256:0ac0f89795dd19de6b97debb0c6af1c70987fd80a2d62d1958f7e56fcc31b497",
+                "sha256:50b6f157849174217d0656f99dc82fe932884fb250826c18350e159ec6cdf342",
+                "sha256:779383f6086d90c99ae41cf0ff39aac8a7937a9283ce0a414e5dd782f4c94a84"
+            ],
+            "markers": "python_version < '3.8'",
+            "version": "==3.10.0.0"
+        },
         "yaspin": {
             "hashes": [
                 "sha256:0498039b3e110f53824417a9f59418a20843e8752b8b15c26bb81a659d4aec5c",
@@ -70,6 +87,14 @@
             ],
             "index": "pypi",
             "version": "==2.0.0"
+        },
+        "zipp": {
+            "hashes": [
+                "sha256:3607921face881ba3e026887d8150cca609d517579abe052ac81fc5aeffdbd76",
+                "sha256:51cb66cc54621609dd593d1787f286ee42a5c0adbb4b29abea5a63edc3e03098"
+            ],
+            "markers": "python_version >= '3.6'",
+            "version": "==3.4.1"
         }
     },
     "develop": {
@@ -206,6 +231,14 @@
             ],
             "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
             "version": "==1.2.0"
+        },
+        "importlib-metadata": {
+            "hashes": [
+                "sha256:833b26fb89d5de469b24a390e9df088d4e52e4ba33b01dc5e0e4f41b81a16c00",
+                "sha256:b142cc1dd1342f31ff04bb7d022492b09920cb64fed867cd3ea6f80fe3ebd139"
+            ],
+            "markers": "python_version < '3.8'",
+            "version": "==4.5.0"
         },
         "iniconfig": {
             "hashes": [
@@ -519,7 +552,7 @@
                 "sha256:50b6f157849174217d0656f99dc82fe932884fb250826c18350e159ec6cdf342",
                 "sha256:779383f6086d90c99ae41cf0ff39aac8a7937a9283ce0a414e5dd782f4c94a84"
             ],
-            "index": "pypi",
+            "markers": "python_version < '3.8'",
             "version": "==3.10.0.0"
         },
         "urllib3": {
@@ -552,6 +585,14 @@
             ],
             "markers": "python_version >= '3.6'",
             "version": "==2.1.2"
+        },
+        "zipp": {
+            "hashes": [
+                "sha256:3607921face881ba3e026887d8150cca609d517579abe052ac81fc5aeffdbd76",
+                "sha256:51cb66cc54621609dd593d1787f286ee42a5c0adbb4b29abea5a63edc3e03098"
+            ],
+            "markers": "python_version >= '3.6'",
+            "version": "==3.4.1"
         }
     }
 }

--- a/src/git_guardrails/validate/__init__.py
+++ b/src/git_guardrails/validate/__init__.py
@@ -40,32 +40,6 @@ def validate_remotes(repo: Repo):
         )
 
 
-def validate_merge_bases_with_default_branch(cli: CLIUX, repo: Repo, active_branch_name: str, default_branch_name: str):
-    merge_bases = repo.merge_base(default_branch_name, active_branch_name)
-    merge_bases_csv = ", ".join(map(lambda c: c.hexsha[0:8], merge_bases))
-    cli.debug(f"merge_bases: {merge_bases_csv}")
-    num_merge_bases = len(merge_bases)
-    if (num_merge_bases == 0):
-        raise UnhandledSituationException(
-            'No merge-base commit found',
-            f"""No merge-base commits between branches {format_branch_name(default_branch_name) } and {
-            format_branch_name(active_branch_name) } could be found, so validation could not be performed.""")
-    if (num_merge_bases > 1):
-        description = " ".join(
-            [
-                f"Multiple ({format_integer(num_merge_bases)}) merge-base commits between branches",
-                format_branch_name(default_branch_name),
-                "and",
-                format_branch_name(active_branch_name),
-                "were found:"
-            ]
-        )
-        commits_description = reduce(lambda a, b: f"{a}\n- {b}", map(format_commit, merge_bases), "")
-        raise UnhandledSituationException(
-            'Multiple merge-base commits found',
-            description + commits_description)
-
-
 def get_branch_information(repo: Repo, branch_name: str) -> Head:
     branch_head: Head = repo.heads[branch_name]
     if (branch_head is None):
@@ -96,66 +70,107 @@ def determine_whether_to_auto_fetch(cli: CLIUX, opts: ValidateOptions, active_br
             cli.warning(f"Invalid response detected: '{user_response}'. Please answer 'Y' or 'N'.")
 
 
+async def validate_branches_and_merge_bases(cli: CLIUX, repo: Repo, opts: ValidateOptions):
+
+    def validate_merge_bases_with_default_branch(cli: CLIUX, repo: Repo, active_branch_name: str, default_branch_name: str):
+        merge_bases = repo.merge_base(default_branch_name, active_branch_name)
+        merge_bases_csv = ", ".join(map(lambda c: c.hexsha[0:8], merge_bases))
+        cli.debug(f"merge_bases: {merge_bases_csv}")
+        num_merge_bases = len(merge_bases)
+        if (num_merge_bases == 0):
+            raise UnhandledSituationException(
+                'No merge-base commit found',
+                f"""No merge-base commits between branches {format_branch_name(default_branch_name) } and {
+                format_branch_name(active_branch_name) } could be found, so validation could not be performed.""")
+        if (num_merge_bases > 1):
+            description = " ".join(
+                [
+                    f"Multiple ({format_integer(num_merge_bases)}) merge-base commits between branches",
+                    format_branch_name(default_branch_name),
+                    "and",
+                    format_branch_name(active_branch_name),
+                    "were found:"
+                ]
+            )
+            commits_description = reduce(lambda a, b: f"{a}\n- {b}", map(format_commit, merge_bases), "")
+            raise UnhandledSituationException(
+                'Multiple merge-base commits found',
+                description + commits_description)
+
+    active_branch = get_branch_information(repo, await opts.get_current_branch_name(repo))  # current_branch
+    cli.debug(f"active branch: {active_branch.name} @ {active_branch.commit.hexsha}")
+    default_branch = get_branch_information(repo, await get_default_git_branch(repo))  # default branch
+    cli.debug(f"default branch: {default_branch.name} @ {default_branch.commit.hexsha}")
+
+    if active_branch == default_branch:
+        raise NonApplicableSituationException(
+            f"You are on the default branch ({default_branch.name})",
+            """git_guardrails is intended to catch potential problems when pushing
+review branches, and will not take any action when on a git repo's default branch""")
+
+    cli.debug('validating merge base between review branch and default branch')
+    validate_merge_bases_with_default_branch(
+        cli=cli,
+        repo=repo,
+        active_branch_name=active_branch,
+        default_branch_name=default_branch
+    )
+    cli.debug('merge base validation complete')
+    return (active_branch)
+
+
+def analyze_review_branch_tracking_situation(cli: CLIUX, repo: Repo, active_branch: Head):
+
+    active_branch_tracked_ref = active_branch.tracking_branch()
+    if (active_branch_tracked_ref is None):
+        raise NonApplicableSituationException(
+            f"Branch {active_branch.name} does not track a remote branch",
+            "The currently active branch does not track a remote branch yet, perhaps you have not pushed it yet?")
+
+    cli.info(f"""determined that local branch {format_branch_name(active_branch.name)} tracks upstream branch {
+            format_branch_name(active_branch_tracked_ref.remote_head)
+            } on remote {format_remote_name(active_branch_tracked_ref.remote_name)}""")
+
+    with yaspin().white.bold as sp:
+        sp.text = f"searching for new upstream commits on {active_branch_tracked_ref.name}"
+        sp.start()
+        latest_remote_sha = git_ls_remote(repo=repo,
+                                          ref=active_branch_tracked_ref,
+                                          ref_types=["heads"])
+        latest_local_sha = active_branch_tracked_ref.commit.hexsha
+        sp.stop()
+        cli.debug(f"latest commit for local ref {active_branch_tracked_ref.name}: {latest_local_sha}")
+        cli.debug(f"""latest commit for tracked branch {active_branch_tracked_ref.remote_head
+                      } on remote {active_branch_tracked_ref.remote_name}: {latest_remote_sha}""")
+
+        return (latest_remote_sha, active_branch_tracked_ref)
+
+
+def offer_to_fetch_from_upstream(cli: CLIUX, repo: Repo, opts: ValidateOptions, active_branch: Head, active_branch_tracked_ref: RemoteReference):
+    cli.warning(f"""New commits on {active_branch_tracked_ref
+                } were detected, which have not yet been pulled down to {active_branch.name}""")
+    determine_whether_to_auto_fetch(cli, opts, active_branch_tracked_ref)
+    origin: Remote = repo.remotes['origin']
+    refspec = f"{active_branch.name}:{active_branch_tracked_ref.name}"
+    cli.info(f"Fetching new commits for branch {active_branch_tracked_ref.name}")
+    cli.debug(f"running 'git fetch' from remote '{origin.name}' with refspec '{refspec}'")
+    origin.fetch()
+    cli.info(f"Fetch from {origin.name} complete")
+
+
 async def do_validate(cli: CLIUX, opts: ValidateOptions):
     try:
         cwd = opts.get_cwd()  # working directory
         repo = Repo(cwd)  # git repo
 
         validate_remotes(repo=repo)
+        (active_branch) = await validate_branches_and_merge_bases(cli=cli, repo=repo, opts=opts)
+        (latest_remote_sha, active_branch_tracked_ref) = analyze_review_branch_tracking_situation(cli, repo, active_branch)
+        has_latest_commits_from_upstream = git_does_commit_exist_locally(repo=repo, sha=latest_remote_sha)
 
-        active_branch = get_branch_information(repo, await opts.get_current_branch_name(repo))  # current_branch
-        cli.debug(f"active branch: {active_branch.name} @ {active_branch.commit.hexsha}")
-        default_branch = get_branch_information(repo, await get_default_git_branch(repo))  # default branch
-        cli.debug(f"default branch: {default_branch.name} @ {default_branch.commit.hexsha}")
-
-        if active_branch == default_branch:
-            raise NonApplicableSituationException(
-                f"You are on the default branch ({default_branch.name})",
-                """git_guardrails is intended to catch potential problems when pushing
-review branches, and will not take any action when on a git repo's default branch""")
-
-        cli.debug('validating merge base between review branch and default branch')
-        validate_merge_bases_with_default_branch(
-            cli=cli,
-            repo=repo,
-            active_branch_name=active_branch,
-            default_branch_name=default_branch
-        )
-        cli.debug('merge base validation complete')
-
-        active_branch_tracked_ref = active_branch.tracking_branch()
-        if (active_branch_tracked_ref is None):
-            raise NonApplicableSituationException(
-                f"Branch {active_branch.name} does not track a remote branch",
-                "The currently active branch does not track a remote branch yet, perhaps you have not pushed it yet?")
-
-        cli.info(f"""determined that local branch {format_branch_name(active_branch.name)} tracks upstream branch {
-            format_branch_name(active_branch_tracked_ref.remote_head)
-            } on remote {format_remote_name(active_branch_tracked_ref.remote_name)}""")
-
-        with yaspin().white.bold as sp:
-            sp.text = f"searching for new upstream commits on {active_branch_tracked_ref.name}"
-            sp.start()
-            latest_remote_sha = git_ls_remote(repo=repo,
-                                              ref=active_branch_tracked_ref,
-                                              ref_types=["heads"])
-            latest_local_sha = active_branch_tracked_ref.commit.hexsha
-            sp.stop()
-            cli.debug(f"latest commit for local ref {active_branch_tracked_ref.name}: {latest_local_sha}")
-            cli.debug(f"""latest commit for tracked branch {active_branch_tracked_ref.remote_head
-                      } on remote {active_branch_tracked_ref.remote_name}: {latest_remote_sha}""")
-
-            has_latest_commits_from_upstream = git_does_commit_exist_locally(repo=repo, sha=latest_remote_sha)
-            if (has_latest_commits_from_upstream == False):
-                cli.warning(f"""New commits on {active_branch_tracked_ref
-                            } were detected, which have not yet been pulled down to {active_branch.name}""")
-                determine_whether_to_auto_fetch(cli, opts, active_branch_tracked_ref)
-                origin: Remote = repo.remotes['origin']
-                refspec = f"{active_branch.name}:{active_branch_tracked_ref.name}"
-                cli.info(f"Fetching new commits for branch {active_branch_tracked_ref.name}")
-                cli.debug(f"running 'git fetch' from remote '{origin.name}' with refspec '{refspec}'")
-                origin.fetch()
-                cli.info(f"Fetch from {origin.name} complete")
+        if (has_latest_commits_from_upstream == False):
+            offer_to_fetch_from_upstream(cli=cli, repo=repo, opts=opts, active_branch=active_branch,
+                                         active_branch_tracked_ref=active_branch_tracked_ref)
     except UserBypassException as ex:
         cli.handle_user_bypass_exception(ex)
     except NonApplicableSituationException as ex:

--- a/tests/scenarios/test_need_to_fetch.py
+++ b/tests/scenarios/test_need_to_fetch.py
@@ -1,4 +1,4 @@
-from logging import INFO
+from logging import INFO  # type: ignore
 from unittest.mock import patch
 from git.refs.head import Head  # type: ignore
 import pytest
@@ -23,6 +23,12 @@ def setup_need_to_fetch_scenario() -> Iterator[Tuple[Repo, Repo]]:
     with temp_repo() as upstream:
         # Create some commit activity on origin/master
         commit_all_modified_tracked_files(upstream, "initial commit")
+        create_git_history(upstream, [
+            ([('old_file1.txt', 'hello from an existing commit!')], 'second commit'),
+            ([('old_file2.txt', 'hello from an existing commit!')], 'third commit'),
+            ([('old_file3.txt', 'hello from an existing commit!')], 'fourth commit'),
+            ([('old_file4.txt', 'hello from an existing commit!')], 'fifth commit'),
+        ])
         # Create a review branch and check it out
         upstream_default_branch = upstream.active_branch
         upstream_review999 = upstream.create_head('review-999')
@@ -103,5 +109,6 @@ async def test_need_to_fetch_upstream_and_downstream_commits(mock_input):
 [WARNING]: New commits on origin/review-999 were detected, which have not yet been pulled down to review-999
 Fetching new commits for branch origin/review-999
 Fetch from origin complete
+Comparing review-999 against origin/review-999
 """
             assert head_before_fetch.hexsha != tracked_branch.commit.hexsha, 'New commits have been pulled down'

--- a/tests/test_validate.py
+++ b/tests/test_validate.py
@@ -81,6 +81,7 @@ async def test_new_upstream_commits_to_pull_down(mock_input_a):
 [WARNING]: New commits on origin/feature-123 were detected, which have not yet been pulled down to feature-123
 Fetching new commits for branch origin/feature-123
 Fetch from origin complete
+Comparing feature-123 against origin/feature-123
 """
 
 


### PR DESCRIPTION
- restore python 3.7 compatibility
- ignore importlib_metadata missing types
- use python 3.7 for code coverage job
- drop redundant ubuntu-latest OS compat build
- refactor do_validate
- local vs upstream analysis
